### PR TITLE
パラメーター授受に使用するエンコーディングを base64url に変更

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -3,8 +3,13 @@
 ## EditBox 初期パラメーターの仕様
 
 EditBox に渡すパラメーターを外部から指定できる。
-パラメーターは所定の形式の JSON を Base64 エンコードした文字列である。
+パラメーターは所定の形式の JSON を base64url でエンコードした文字列である。
 これを URL の query string パラメーター p に指定する。
+
+### base64url とは
+
+Base64 を URL safe にしたもの。
+
 
 ### JSON Format
 
@@ -41,19 +46,33 @@ EditBox に渡すパラメーターを外部から指定できる。
             "material": "剣輝",
             "initial": 82,
         }
-    ]
+    ],
+    "note": "骨泥UP %"
 }
 ```
 
-これを Base64 エンコードすると
+これを base64url でエンコードすると
 
 ```js
-btoa(unescape(encodeURIComponent(JSON.stringify(data))))
-"eyJxdWVzdG5hbWUiOiLlhqzmnKgg5pyq56K66KqN5bqn5qiZWC1BIiwicnVucyI6NTAwLCJsaW5lcyI6W3sibWF0ZXJpYWwiOiLpqqgiLCJpbml0aWFsIjo1MH0seyJtYXRlcmlhbCI6IuWJo+i8nSIsImluaXRpYWwiOjgyfV19"
+function base64urlencode(text) {
+    return btoa(unescape(encodeURIComponent(text)))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+}
+
+base64urlencode(JSON.stringify(data))
+=> eyJxdWVzdG5hbWUiOiLlhqzmnKgg5pyq56K66KqN5bqn5qiZWC1BIiwicnVucyI6NT
+AwLCJsaW5lcyI6W3sibWF0ZXJpYWwiOiLpqqgiLCJpbml0aWFsIjo1MH0seyJtYXRlcml
+hbCI6IuWJo-i8nSIsImluaXRpYWwiOjgyfV0sIm5vdGUiOiLpqqjms6VVUCAlIn0
+// 見やすいように改行を入れているが、実際は 1 行
 ```
 
 これを URL の query string パラメーター p に指定すると
 
 ```
-/?p=eyJxdWVzdG5hbWUiOiLlhqzmnKgg5pyq56K66KqN5bqn5qiZWC1BIiwicnVucyI6NTAwLCJsaW5lcyI6W3sibWF0ZXJpYWwiOiLpqqgiLCJpbml0aWFsIjo1MH0seyJtYXRlcmlhbCI6IuWJo+i8nSIsImluaXRpYWwiOjgyfV19
+// 見やすいように改行を入れているが、実際は 1 行
+/?p=eyJxdWVzdG5hbWUiOiLlhqzmnKgg5pyq56K66KqN5bqn5qiZWC1BIiwicnVucyI6N
+TAwLCJsaW5lcyI6W3sibWF0ZXJpYWwiOiLpqqgiLCJpbml0aWFsIjo1MH0seyJtYXRlcm
+lhbCI6IuWJo-i8nSIsImluaXRpYWwiOjgyfV0sIm5vdGUiOiLpqqjms6VVUCAlIn0
 ```

--- a/src/components/molecules/QuestData.js
+++ b/src/components/molecules/QuestData.js
@@ -19,9 +19,13 @@ function QuestData({ children }) {
           note: "",
         };
       }
+      const base64str = searchParams
+          .get("p")
+          .replace(/-/g, "+")
+          .replace(/_/g, "/");
       const byteArray = new Uint8Array(
         window
-          .atob(searchParams.get("p"))
+          .atob(base64str)
           .split("")
           .map((c) => c.charCodeAt(0))
       );


### PR DESCRIPTION
base64 は url safe でないためそのまま使用すると問題が生じる。
encode 側 (fgosccalc, fgosccnt) も対応が必要。