### PR TITLE
#28への対応

### DIFF
--- a/src/components/atoms/button/ReportButton.js
+++ b/src/components/atoms/button/ReportButton.js
@@ -86,19 +86,19 @@ function createReportJSON(
   ];
 
   let warName = null;
-  let questName = questname;
+  let questName = questname.replace(/　/g, " ");
 
   for (const normalWarName of normalWarNames) {
-    if (questname.startsWith(normalWarName + " ")) {
-      const splitQuestName = questname.split(" ");
+    if (questName.startsWith(normalWarName + " ")) {
+      const splitQuestName = questName.split(" ");
       warName = splitQuestName[0];
-      questName = splitQuestName.slice(1).join(" ");
+      questName = splitQuestName[1];
       break;
     }
   }
   for (const chaldeaGateWarName of chaldeaGateWarNames) {
-    if (questname.startsWith(chaldeaGateWarName + " ")) {
-      const splitQuestName = questname.split(" ");
+    if (questName.startsWith(chaldeaGateWarName + " ")) {
+      const splitQuestName = questName.split(" ");
       warName = "カルデアゲート";
       break;
     }

--- a/src/components/organisms/reports/detail/ReportForm.js
+++ b/src/components/organisms/reports/detail/ReportForm.js
@@ -16,6 +16,7 @@ import {
 import ReportTable from "./ReportTable";
 
 const ReportForm = ({
+  isAdmin,
   isEditable,
   questType,
   setQuestType,
@@ -44,7 +45,8 @@ const ReportForm = ({
         <Input
           value={warName}
           onChange={(e) => setWarName(e.target.value)}
-          isReadOnly={!isEditable}
+          isReadOnly={!isAdmin}
+          isEditable={isAdmin}
         />
       </FormControl>
       <FormControl>
@@ -52,7 +54,8 @@ const ReportForm = ({
         <Input
           value={questName}
           onChange={(e) => setQuestName(e.target.value)}
-          isReadOnly={!isEditable}
+          isReadOnly={!isAdmin}
+          isEditable={isAdmin}
         />
       </FormControl>
       <FormControl>

--- a/src/components/templates/ReportDetails.js
+++ b/src/components/templates/ReportDetails.js
@@ -37,6 +37,7 @@ const ReportDetails = () => {
   const [note, setNote] = useState("");
   const [dropObjects, setDropObjects] = useState([]);
   const [cognitoId, setCognitoId] = useState(null);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     const getUserInfo = async () => {
@@ -63,6 +64,9 @@ const ReportDetails = () => {
         const user = await Auth.currentAuthenticatedUser();
         const groups =
           user.signInUserSession.accessToken.payload["cognito:groups"];
+        if (groups && groups.includes("Admin")) {
+          setIsAdmin(true);
+        }
         setIsEditable(
           (groups && groups.includes("Admin")) ||
             (reportData.data.getReport &&
@@ -164,6 +168,7 @@ const ReportDetails = () => {
         <VStack spacing={1} align="start">
           <ReportHeader report={report} />
           <ReportForm
+            isAdmin={isAdmin}
             report={report}
             questType={questType}
             setQuestType={setQuestType}


### PR DESCRIPTION
- クエスト名に全角スペースが入っている場合半角スペースに変換
- 3Wordでクエスト名が入力されたら、1Word目を場所(war), 2Word目をクエスト名(questName)に
- 管理者は場所名とクエスト名のUI上での変更を可能に